### PR TITLE
Fix missing imports in runner

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -1,5 +1,6 @@
 import time
-from typing import List
+import traceback
+from typing import List, Optional
 import cv2
 import numpy as np
 import mss


### PR DESCRIPTION
## Summary
- add Optional typing and traceback import in MacroRunner

## Testing
- `python main.py` *(fails: KeyError: 'DISPLAY')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfdfad0c5c8327b957869c4d951c06