### PR TITLE
Fix missing imports in recorder and GUI

### DIFF
--- a/core/recorder.py
+++ b/core/recorder.py
@@ -1,11 +1,20 @@
-from typing import List
+from typing import List, Optional
 import time
 import json
 import pyautogui
 from PyQt5.QtCore import QObject, QRect, pyqtSignal
 from pynput import keyboard, mouse
 
-from utils import info, warn, err, encode_png_bytes, _normalize_point_result, safe_select_point
+from utils import (
+    info,
+    warn,
+    err,
+    encode_png_bytes,
+    _normalize_point_result,
+    safe_select_point,
+    hk_normalize,
+    hk_to_tuple,
+)
 from core.models import StepData
 
 

--- a/core/runner.py
+++ b/core/runner.py
@@ -1,5 +1,6 @@
 import time
-from typing import List
+import traceback
+from typing import List, Optional
 import cv2
 import numpy as np
 import mss

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,12 +1,12 @@
 import json
 import uuid
 import traceback
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import cv2
 import pyautogui
-from PyQt5.QtCore import Qt, QRect, QPoint, QSize, QSettings, QTimer, QEventLoop, QObject
+from PyQt5.QtCore import Qt, QRect, QPoint, QSize, QSettings, QTimer, QEventLoop, QObject, pyqtSignal
 from PyQt5.QtGui import QGuiApplication, QPixmap, QImage, QPainter, QColor, QIcon, QKeySequence
 from PyQt5.QtWidgets import (
     QApplication, QWidget, QLabel, QPushButton, QVBoxLayout, QHBoxLayout, QGridLayout,


### PR DESCRIPTION
## Summary
- include Optional and hotkey helpers in the input recorder
- add pyqtSignal and Optional typing to the main window

## Testing
- `xvfb-run -a python main.py` *(fails: Could not load the Qt platform plugin "xcb")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfdfad0c5c8327b957869c4d951c06