### PR TITLE
멀티스케일 파라미터 명칭 정리

### DIFF
--- a/utils/image.py
+++ b/utils/image.py
@@ -194,9 +194,9 @@ class Matcher:
             return []
 
     def _multiscale(self, img_pp, tpl_pp, step, th, delta, over_budget_cb):
-        scales = np.linspace(float(getattr(step, "ms_scale_min", 0.7)),
-                             float(getattr(step, "ms_scale_max", 1.3)),
-                             int(getattr(step, "ms_scale_steps", 5)))
+        scales = np.linspace(float(getattr(step, "ms_min_scale", 0.7)),
+                             float(getattr(step, "ms_max_scale", 1.3)),
+                             int(getattr(step, "ms_step", 5)))
         best = []
         best_seen = -1.0
         for sc in scales:


### PR DESCRIPTION
## Summary
- `_multiscale` 함수에서 멀티스케일 관련 파라미터 명칭을 최신 모델과 일치하도록 수정

## Testing
- `python - <<'PY'
import sys, types, importlib.util
qt = types.ModuleType('PyQt5'); qtgui = types.ModuleType('PyQt5.QtGui')
class Dummy: pass
qtgui.QPixmap = Dummy; qtgui.QImage = Dummy
qt.QtGui = qtgui
sys.modules['PyQt5'] = qt
sys.modules['PyQt5.QtGui'] = qtgui

spec = importlib.util.spec_from_file_location('image_module', '/workspace/coding2/utils/image.py')
image = importlib.util.module_from_spec(spec)
spec.loader.exec_module(image)

import numpy as np
import cv2

frame = np.full((200,200,3), 255, dtype=np.uint8)
tpl = np.zeros((20,20,3), dtype=np.uint8)
cv2.rectangle(tpl, (5,5), (15,15), (0,0,255), -1)
frame[80:100, 120:140] = tpl

class Step:
    pre_gray=True
    pre_blur_ksize=1
    pre_clahe=False
    pre_edge=False
    pre_sharpen=False
    ms_enable=True
    ms_min_scale=0.5
    ms_max_scale=1.5
    ms_step=5
    top_k=1
step = Step()

matcher = image.Matcher()
img_pp_data = image._apply_preprocess(frame, step)
tpl_pp = image._apply_preprocess(tpl, step)
best, info = matcher._multiscale(img_pp_data, tpl_pp, step, th=0.5, delta=0.03, over_budget_cb=lambda: False)
print('scales:', info['scales'])
print('best:', best[:1])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c0208a935883279bd555b8c54caeac