### PR TITLE
chore: remove unused pyautogui import

### DIFF
--- a/core/recorder.py
+++ b/core/recorder.py
@@ -1,17 +1,10 @@
 from typing import List, Optional
 import time
 import uuid
-import pyautogui
 from PyQt5.QtCore import QObject, QRect, pyqtSignal
 from pynput import keyboard, mouse
 
 from utils import (
-    info,
-    warn,
-    err,
-    encode_png_bytes,
-    _normalize_point_result,
-    safe_select_point,
     hk_normalize,
     hk_to_tuple,
 )


### PR DESCRIPTION
## Summary
- remove unused imports from core/recorder.py

## Testing
- `flake8 core/recorder.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c026853df08327999c5427c7f27ff4