### PR TITLE
fix: import hotkey utilities

### DIFF
--- a/core/recorder.py
+++ b/core/recorder.py
@@ -1,17 +1,10 @@
 from typing import List, Optional
 import time
 import uuid
-import pyautogui
 from PyQt5.QtCore import QObject, QRect, pyqtSignal
 from pynput import keyboard, mouse
 
 from utils import (
-    info,
-    warn,
-    err,
-    encode_png_bytes,
-    _normalize_point_result,
-    safe_select_point,
     hk_normalize,
     hk_to_tuple,
 )

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -10,7 +10,7 @@ from PyQt5.QtWidgets import (
     QComboBox, QMessageBox, QCheckBox, QApplication
 )
 
-from utils import cvimg_to_qpixmap, encode_png_bytes, _normalize_point_result, info
+from utils import cvimg_to_qpixmap, encode_png_bytes, _normalize_point_result, info, hk_normalize
 from core.models import StepData
 from gui.overlays import ROISelector, PointSelector
 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+import time
 import traceback
 from typing import List, Optional
 
@@ -16,7 +17,17 @@ from PyQt5.QtWidgets import (
     QMessageBox, QShortcut, QDialogButtonBox, QGroupBox, QComboBox, QMenu, QInputDialog
 )
 
-from utils import cvimg_to_qpixmap, encode_png_bytes, info, warn, err, make_letter_icon, hk_pretty
+from utils import (
+    cvimg_to_qpixmap,
+    encode_png_bytes,
+    info,
+    warn,
+    err,
+    make_letter_icon,
+    hk_pretty,
+    hk_normalize,
+    hk_to_tuple,
+)
 from core.models import StepData, RepeatConfig
 from core.runner import MacroRunner
 from core.recorder import InputRecorder


### PR DESCRIPTION
## Summary
- ensure GUI hotkey features import required helpers
- expose hotkey normalization in dialog module

## Testing
- `python -m flake8 gui/main_window.py` *(fails: existing style issues)*
- `python -m flake8 gui/dialogs.py` *(fails: existing style issues)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68c026853df08327999c5427c7f27ff4