### PR TITLE
Refactor scenario serialization in save_macro

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -683,7 +683,17 @@ class MainWindow(QMainWindow):
         if not path: return
         try:
             with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as z:
-                scen = {"version": 8, "repeat": {"repeat_count": self.sbRepeatCount.value(), "repeat_cooldown_ms": self.sbCooldown.value(), "stop_on_fail": self.cbStopOnFail.isChecked(), "max_duration_ms": self.sbMaxDuration.value()}, "steps": [s.to_serializable() for s in self.steps]}
+                repeat_cfg = RepeatConfig(
+                    repeat_count=self.sbRepeatCount.value(),
+                    repeat_cooldown_ms=self.sbCooldown.value(),
+                    stop_on_fail=self.cbStopOnFail.isChecked(),
+                    max_duration_ms=self.sbMaxDuration.value(),
+                )
+                scen = {
+                    "repeat": asdict(repeat_cfg),
+                    "steps": [s.to_serializable() for s in self.steps],
+                    "version": 8,
+                }
                 z.writestr("scenario.json", json.dumps(scen, ensure_ascii=False, indent=2))
                 for s in self.steps:
                     if s.type == "image_click" and s.png_bytes:


### PR DESCRIPTION
## Summary
- restructure scen dictionary in save_macro for readability
- extract RepeatConfig data into local variable

## Testing
- `black --check gui/main_window.py` *(fails: would reformat)*
- `flake8 gui/main_window.py` *(fails: unused imports, line length, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c030876f54832789ca4fc68968e95c