### PR TITLE
Handle missing macro images gracefully

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -712,8 +712,11 @@ class MainWindow(QMainWindow):
                 for d in scen.get("steps", []):
                     png = None
                     if d.get("image_path"):
-                        try: png = z.read(d["image_path"])
-                        except: png = None
+                        try:
+                            png = z.read(d["image_path"])
+                        except Exception as e:
+                            self.info(f"Failed to read image '{d['image_path']}' from '{path}': {e}. Skipping step.")
+                            continue
                     
                     # Get all fields from dataclass to build the object
                     valid_fields = {f.name for f in dataclass_fields(StepData)}


### PR DESCRIPTION
## Summary
- Avoid bare exceptions when loading macro step images
- Log failing image paths and skip steps if image extraction fails

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c030883ed883279398bd449070c588