### PR TITLE
fix: 드래그 좌표 선택 함수 임포트

### DIFF
--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -12,7 +12,14 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtGui import QKeySequence, QCursor
 
-from utils import cvimg_to_qpixmap, encode_png_bytes, _normalize_point_result, info, hk_normalize
+from utils import (
+    cvimg_to_qpixmap,
+    encode_png_bytes,
+    _normalize_point_result,
+    info,
+    hk_normalize,
+    safe_select_point,
+)
 from core.models import StepData
 from gui.overlays import ROISelector, PointSelector
 
@@ -334,7 +341,7 @@ class NotImageDialog(QDialog):
             except Exception: pass
 
             # 좌표 픽커 실행 (parent=None 권장)
-            res = _safe_select_point(None)
+            res = safe_select_point(None)
             norm = _normalize_point_result(res)
             if norm is None:
                 info("Point selection canceled or failed.")


### PR DESCRIPTION
## Summary
- 드래그 좌표 픽커가 작동하도록 `safe_select_point` 함수 임포트 및 호출 수정

## Testing
- `pytest -q`
- `python -m py_compile gui/dialogs.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0eaa3a1d48327978f391c9293c5f3