### PR TITLE
Not-image 스텝 추가 시 선택·스크롤 및 미리보기 갱신

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -541,7 +541,11 @@ class MainWindow(QMainWindow):
         if dlg.exec_() == QDialog.Accepted:
             s = dlg.result_step()
             if s:
-                self.steps.append(s); self.add_list_item(s)
+                self.steps.append(s)
+                self.add_list_item(s)
+                self.list.setCurrentRow(self.list.count() - 1)
+                self.list.scrollToItem(self.list.currentItem())
+                self.update_preview()
         # 안전핀: 포커스 복구
         self.raise_(); self.activateWindow()
 


### PR DESCRIPTION
## Summary
- Not-image 스텝 추가 직후 리스트에서 새 항목을 선택하고 스크롤하여 가시성을 확보
- 새 항목 선택 후 미리보기 갱신 보장

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c10f7a90248327aa25bdd0ea83f541