### PR TITLE
Remove dialog result dependency in NotImageDialog

### DIFF
--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -607,8 +607,6 @@ class NotImageDialog(QDialog):
 
     # ---- 결과 구성 ----
     def result_step(self) -> Optional[StepData]:
-        if self.result() != QDialog.Accepted:
-            return None
         t = self.cbType.currentText().strip()
         name = self.edName.text().strip() or t
         key_string = self.edKey.text().strip()


### PR DESCRIPTION
## Summary
- Build NotImageDialog step data without checking QDialog.Accepted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12469e5388327bb9774191379cebf