### PR TITLE
Refactor drag sequence and button support

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -369,13 +369,16 @@ class MacroRunner(QThread):
             self.requestCrosshair.emit(int(s.drag_to_x), int(s.drag_to_y), 200)
             return True
         try:
+            btn = s.click_button or "left"
             pyautogui.moveTo(int(s.drag_from_x), int(s.drag_from_y))
-            pyautogui.dragTo(int(s.drag_to_x), int(s.drag_to_y),
-                             max(1, int(s.drag_duration_ms)) / 1000.0)
-            pyautogui.mouseDown(button=s.click_button or "left")
-            self.msleep(max(1, int(s.drag_duration_ms)))
-            pyautogui.moveTo(int(s.drag_to_x), int(s.drag_to_y))
-            pyautogui.mouseUp(button=s.click_button or "left")
+            pyautogui.mouseDown(button=btn)
+            pyautogui.dragTo(
+                int(s.drag_to_x),
+                int(s.drag_to_y),
+                max(1, int(s.drag_duration_ms)) / 1000.0,
+                button=btn,
+            )
+            pyautogui.mouseUp(button=btn)
             return True
         except Exception as e:
             self.log.emit(f"  !! drag err: {e}")


### PR DESCRIPTION
## Summary
- restructure drag actions to moveTo → mouseDown → dragTo → mouseUp
- allow selecting mouse button by passing the configured button to all drag-related mouse calls
- remove unnecessary sleep and extra moveTo

## Testing
- `/usr/bin/python3 -m py_compile core/runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68c14a64136083278b800725c8c2813b